### PR TITLE
Add auto-generated sitemap.xml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,8 @@ minima:
 # Build settings
 markdown: kramdown
 theme: minima
-plugins: []
+plugins:
+  - jekyll-sitemap
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
For possibly easier navigation and some crawlers like it.

Example usage: `docker run -it --rm --net=host aleravat/crowlet --crawl-hyperlinks --crawl-external --crawl-images 'http://127.0.0.1:4000/sitemap.xml'`